### PR TITLE
0.1.2: subprocess fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: test
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'TODO.md'
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: unittests python-${{ matrix.python-version }} ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.11"
+        os:
+          # not latest because this is last version that supports python-3.7
+          - ubuntu-22.04
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install git+https://github.com/python-poetry/poetry.git@5bab98c9500f1050c6bb6adfb55580a23173f18d
+      - name: Install Python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          update-environment: false
+      - run: poetry env use ${{ steps.setup-python.outputs.python-path }}
+      - run: poetry install --extras "tests" --no-interaction --no-cache -vvv
+      - run: poetry run pytest ./tests
+        name: run pytest (all)
+        if: ${{ !github.event.pull_request.draft }}
+      - run: poetry run pytest ./tests -m "not slow"
+        name: run pytest (not slow)
+        if: ${{ github.event.pull_request.draft }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           update-environment: false
       - run: poetry env use ${{ steps.setup-python.outputs.python-path }}
-      - run: poetry install --extras "tests" --no-interaction --no-cache -vvv
+      - run: poetry install --extras "dev" --no-interaction --no-cache -vvv
       - run: poetry run pytest ./tests
         name: run pytest (all)
         if: ${{ !github.event.pull_request.draft }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage.xml
 
 # logging files
 *.log
+
+# project specific
+.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2025-01-??
+
+### fixed
+
+- rez-env subprocess execution on UNIX system
+
+### changed
+
+- the launcher will now raise if it can't find a path to the `rez-env` executable
+  using `shutil.which`.
+
+### chores
+
+- added e2e tests which actually call rez

--- a/README.md
+++ b/README.md
@@ -3,3 +3,33 @@
 ![Made with Python](https://img.shields.io/badge/Python->=3.7-blue?logo=python&logoColor=white)
 
 Launcher plugin for [Kloch](https://github.com/knotsanimation/kloch) implementing support for [rez](https://rez.readthedocs.io).
+
+# installation
+
+See https://knotsanimation.github.io/kloch/launcher-plugins.html for installation.
+
+# usage
+
+Defines 3 options:
+
+- `requires`: mapping of package name / package version
+- `params`: see https://rez.readthedocs.io/en/stable/commands/rez-env.html
+- `config`: build a valid yaml rez config, see https://rez.readthedocs.io/en/stable/configuring_rez.html
+
+
+Example in a profile:
+
+```yml
+__magic__: kloch_profile:4
+identifier: demo
+version: 0.1.0
+launchers:
+  rezenv:
+    requires:
+      testpkg: 1.2.3
+    params:
+      - "-vvv"
+  rezenv@os=windows:
+    config:
+      default_shell: "powershell"
+```

--- a/kloch_rezenv/__init__.py
+++ b/kloch_rezenv/__init__.py
@@ -1,3 +1,5 @@
 from ._dataclass import RezEnvLauncher
 from ._serialized import RezEnvLauncherFields
 from ._serialized import RezEnvLauncherSerialized
+
+__version__ = "0.1.2"  # keep in sync with pyproject.toml

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,33 +2,33 @@
 
 [[package]]
 name = "black"
-version = "24.8.0"
+version = "24.10.0"
 description = "The uncompromising code formatter."
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
+    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
+    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
+    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
+    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
+    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
+    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
+    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
 ]
 
 [package.dependencies]
@@ -42,19 +42,19 @@ typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "click"
-version = "8.1.7"
+version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
 ]
 
 [package.dependencies]
@@ -118,13 +118,13 @@ files = [
 
 [[package]]
 name = "kloch"
-version = "0.11.2"
+version = "0.12.0"
 description = "Environment Manager CLI wrapping package managers calls as serialized config file"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "kloch-0.11.2-py3-none-any.whl", hash = "sha256:0e888ce83844b050d7ea1de9763dc0f53870bcac96c4dc9caea58418dd7b072c"},
-    {file = "kloch-0.11.2.tar.gz", hash = "sha256:c29200401f47d22a5f81d1fd4301b0ba884133006c8a8cd3e956adc00f9d06d7"},
+    {file = "kloch-0.12.0-py3-none-any.whl", hash = "sha256:ea6408611ef3ac789d0e70354726de17a000e8f1b2ecd5c53c063f20218dcc3a"},
+    {file = "kloch-0.12.0.tar.gz", hash = "sha256:fe8a9debb6740408fb276f735cbadb88c122f65070a6c62de88ad2f68be9fdbd"},
 ]
 
 [package.dependencies]
@@ -170,19 +170,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.2.2"
+version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
-    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
-type = ["mypy (>=1.8)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kloch_rezenv"
-version = "0.1.1"
+version = "0.1.2"  # keep in sync with __init__.py
 description = "Launcher plugin for Kloch implementing support for rez."
 authors = ["Liam Collod <monsieurlixm@gmail.com>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+import pytest
+
+THISDIR = Path(__file__).parent
+
+
+@pytest.fixture
+def data_dir() -> Path:
+    return THISDIR / "data"

--- a/tests/data/profile.e2e.1.yml
+++ b/tests/data/profile.e2e.1.yml
@@ -1,0 +1,17 @@
+__magic__: kloch_profile:4
+identifier: rezenv-plugin-test
+version: 0.1.0
+launchers:
+  .base:
+    environ:
+      PATH:
+        - $PATH
+        - $__TEST_REZ_INSTALL_DIR
+  rezenv:
+    requires:
+      testpkg: 1.2.3
+    params:
+      - "-vvv"
+  rezenv@os=windows:
+    config:
+      default_shell: "powershell"

--- a/tests/data/rezrepo/testpkg/1.2.3/package.py
+++ b/tests/data/rezrepo/testpkg/1.2.3/package.py
@@ -1,0 +1,7 @@
+name = "testpkg"
+
+version = "1.2.3"
+
+
+def commands():
+    env.TESTPKG_CONFIRM_VAR = "CONFIRMED"

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+   slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,6 +7,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
+import pytest
+
 import kloch
 import kloch_rezenv
 
@@ -78,6 +80,7 @@ def install_rez(
     shutil.rmtree(rez_tmp_dir)
 
 
+@pytest.mark.slow
 def test__e2e_kloch_rezenv(tmp_path, data_dir):
 
     rez_version = "2.114.1"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,126 @@
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import kloch
+import kloch_rezenv
+
+LOGGER = logging.getLogger(__name__)
+
+THISDIR = Path(__file__).parent
+
+REZ_BASE_URL = "https://github.com/AcademySoftwareFoundation/rez/archive/refs/tags/{rez_version}.zip"
+
+TESTS_CACHE_DIR = THISDIR / ".cache"
+if not TESTS_CACHE_DIR.exists():
+    print(f"mkdir({TESTS_CACHE_DIR})")
+    TESTS_CACHE_DIR.mkdir()
+
+REZ_INSTALL_CACHE = TESTS_CACHE_DIR / "rez"
+
+
+def extract_zip(zip_path: Path, remove_zip=True):
+    extract_root = zip_path.parent
+    with zipfile.ZipFile(zip_path, "r") as zip_file:
+        zip_file.extractall(extract_root)
+
+    if remove_zip:
+        zip_path.unlink()
+
+    return extract_root
+
+
+def install_rez(
+    rez_version: str,
+    python_executable: Path,
+    target_dir: Path,
+) -> Path:
+    """
+    Create a rez installation with the given configuration.
+
+    Args:
+        rez_version: full rez version to download from GitHub
+        python_executable: filesystem path to the python executable to install rez with.
+        target_dir: filesystem path to an empty existing directory
+
+    Returns:
+        filesystem path to the rez executable in the ``target_dir``.
+    """
+    rez_url = REZ_BASE_URL.format(rez_version=rez_version)
+    rez_tmp_dir = target_dir / "__installer"
+    rez_tmp_dir.mkdir()
+    rez_zip_path = target_dir / "rez.zip"
+
+    LOGGER.info(f"downloading '{rez_url}' to '{rez_zip_path}' ...")
+    with urllib.request.urlopen(rez_url) as dl_stream, rez_zip_path.open(
+        "wb"
+    ) as dl_file:
+        shutil.copyfileobj(dl_stream, dl_file)
+
+    rez_root = extract_zip(zip_path=rez_zip_path, remove_zip=True)
+    rez_installer_path = rez_root / f"rez-{rez_version}" / "install.py"
+    rez_command = [
+        str(python_executable),
+        str(rez_installer_path),
+        str(target_dir),
+    ]
+    LOGGER.info(f"installing rez to '{target_dir}'")
+    LOGGER.debug(f"subprocess.run({rez_command})")
+    result = subprocess.run(
+        rez_command,
+        check=True,
+    )
+    shutil.rmtree(rez_tmp_dir)
+
+
+def test__e2e_kloch_rezenv(tmp_path, data_dir):
+
+    rez_version = "2.114.1"
+
+    if not REZ_INSTALL_CACHE.exists():
+        REZ_INSTALL_CACHE.mkdir()
+        try:
+            install_rez(rez_version, Path(sys.executable), REZ_INSTALL_CACHE)
+        except Exception:
+            shutil.rmtree(REZ_INSTALL_CACHE)
+            raise
+    else:
+        print(f"found rez already installed at {REZ_INSTALL_CACHE}")
+
+    if sys.platform in ("win32", "cygwin"):
+        rez_bin_dir = REZ_INSTALL_CACHE / "Scripts" / "rez"
+        check_command = ["--", "echo", "$Env:REZ_VERSION", "$Env:TESTPKG_CONFIRM_VAR"]
+    else:
+        rez_bin_dir = REZ_INSTALL_CACHE / "bin" / "rez"
+        check_command = ["--", "echo", "$REZ_VERSION", "$TESTPKG_CONFIRM_VAR"]
+
+    environ = os.environ.copy()
+    environ[kloch.Environ.CONFIG_LAUNCHER_PLUGINS] = kloch_rezenv.__name__
+    environ[kloch.Environ.CONFIG_CLI_SESSION_PATH] = str(tmp_path)
+    environ[kloch.Environ.CONFIG_PROFILE_ROOTS] = str(data_dir)
+    environ["__TEST_REZ_INSTALL_DIR"] = str(rez_bin_dir)
+    environ["REZ_PACKAGES_PATH"] = str(data_dir / "rezrepo")
+
+    command = [
+        sys.executable,
+        "-m",
+        "kloch",
+        "run",
+        "rezenv-plugin-test",
+        "--debug",
+    ]
+    command += check_command
+    result = subprocess.run(command, env=environ, capture_output=True, text=True)
+    print("=== [stdout] ===")
+    print(result.stdout)
+    print("=== [stderr] ===")
+    print(result.stderr)
+    assert not result.returncode
+    # "CONFIRMED" from ./data/rezrepo/testpkg/1.2.3/package.py
+    expected = rez_version + "\nCONFIRMED"
+    assert expected in result.stdout

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -100,7 +100,7 @@ def test__e2e_kloch_rezenv(tmp_path, data_dir):
         check_command = ["--", "echo", "$Env:REZ_VERSION", "$Env:TESTPKG_CONFIRM_VAR"]
     else:
         rez_bin_dir = REZ_INSTALL_CACHE / "bin" / "rez"
-        check_command = ["--", "echo", "$REZ_VERSION", "$TESTPKG_CONFIRM_VAR"]
+        check_command = ["--", "echo", "$REZ_VERSION\n$TESTPKG_CONFIRM_VAR"]
 
     environ = os.environ.copy()
     environ[kloch.Environ.CONFIG_LAUNCHER_PLUGINS] = kloch_rezenv.__name__

--- a/tests/test_kloch_rezenv.py
+++ b/tests/test_kloch_rezenv.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import subprocess
 import sys
 from typing import Dict
@@ -26,7 +27,9 @@ def test__RezEnvLauncher(monkeypatch, tmp_path):
         rezenv_path = rezenv_dir / "rez-env.EXE"
     else:
         rezenv_path = rezenv_dir / "rez-env"
-    rezenv_path.write_text("placeholder")
+    rezenv_path.write_text("echo placeholder")
+    current_stats = os.stat(rezenv_path)
+    os.chmod(rezenv_path, current_stats.st_mode | stat.S_IEXEC)
 
     monkeypatch.setattr(subprocess, "run", patched_subprocess)
     environ_new_path = str(rezenv_dir) + os.pathsep + os.environ.get("PATH", "")


### PR DESCRIPTION
## Changelog

### fixed

- rez-env subprocess execution on UNIX system

### changed

- the launcher will now raise if it can't find a path to the `rez-env` executable
  using `shutil.which`.

### chores

- added e2e tests which actually call rez